### PR TITLE
[Feature] Custom resolv.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,19 @@ Once it connects run this command
   
 ```adb shell "/system/bin/device_config put activity_manager max_phantom_processes 2147483647"```
 
+# DNS problem fix
+If you're facing DNS issue during the installation process (can't do apt-update or apt install). Create new `resolv.conf` file using nano on the termux home path (`~`) and define the DNS server you want to use.
+
+`resolv.conf` file example:
+```
+nameserver 8.8.8.8
+nameserver 1.1.1.1
+```
+
+if you're facing this issue during the installation process, you need to remove the proot again before able to start the installation again, execute this command
+```
+proot-distro remove debian
+```
+```
+./setup.sh
+```

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ nameserver 8.8.8.8
 nameserver 1.1.1.1
 ```
 
-if you're facing this issue during the installation process, you need to remove the proot again before able to start the installation again, execute this command
+this issue might be appear during the installation process, and you need to remove the proot again before able to re-start the installation. Execute this command to remove the distro and start the installation process:
 ```
 proot-distro remove debian
 ```

--- a/setup.sh
+++ b/setup.sh
@@ -37,6 +37,16 @@ mkdir -p Downloads
 setup_proot() {
 #Install Debian proot
 proot-distro install debian
+
+# Check if the custom resolv.conf file exists
+if [ -e "$HOME/resolv.conf" ]; then
+  # Copy the file to the destination path
+  cp "$HOME/resolv.conf" "$HOME/../usr/var/lib/proot-distro/installed-rootfs/debian/etc/resolv.conf"
+  echo "Custom resolv.conf successfully copied"
+else
+  echo "No custom resolv.conf found, skipping replacement process..."
+fi
+
 proot-distro login debian --shared-tmp -- env DISPLAY=:1.0 apt update
 proot-distro login debian --shared-tmp -- env DISPLAY=:1.0 apt upgrade -y
 proot-distro login debian --shared-tmp -- env DISPLAY=:1.0 apt install sudo wget nala flameshot conky-all -y


### PR DESCRIPTION
This feature is used for resolve DNS issue during the installation process (can't do apt-update or apt install). 

How it works:
- Create new `resolv.conf` file using nano on the termux home path (`~`)
- resolv.conf will be copied to `/etc/resolv.conf` inside the debian folder after the proot-distro installation process

This will be an optional feature, so it will not run if user is not create resolv.conf in termux homepath