### PR TITLE
move to eza from exa

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -71,7 +71,7 @@ proot-distro login debian --shared-tmp -- env DISPLAY=:1.0 cp /usr/share/zoneinf
 
 setup_xfce() {
 #Install xfce4 desktop and additional packages
-pkg install git neofetch virglrenderer-android papirus-icon-theme xfce4 xfce4-goodies pavucontrol-qt exa bat jq nala wmctrl firefox netcat-openbsd -y
+pkg install git neofetch virglrenderer-android papirus-icon-theme xfce4 xfce4-goodies pavucontrol-qt eza bat jq nala wmctrl firefox netcat-openbsd -y
 
 #Create .bashrc
 cp $HOME/../usr/var/lib/proot-distro/installed-rootfs/debian/etc/skel/.bashrc $HOME/.bashrc
@@ -88,7 +88,7 @@ source .sound" >> .bashrc
 #Set aliases
 echo "
 alias debian='proot-distro login debian --user $username --shared-tmp'
-alias ls='exa -lF --icons'
+alias ls='eza -lF --icons'
 alias cat='bat '
 alias apt='pkg upgrade -y && nala $@'
 " >> $HOME/.bashrc

--- a/setup.sh
+++ b/setup.sh
@@ -57,7 +57,7 @@ echo "export DISPLAY=:1.0" >> $HOME/../usr/var/lib/proot-distro/installed-rootfs
 #Set proot aliases
 echo "
 alias virgl='GALLIUM_DRIVER=virpipe '
-alias ls='exa -lF --icons'
+alias ls='eza -lF --icons'
 alias cat='bat '
 alias apt='sudo nala '
 alias start='echo "please run from termux, not debian proot."'


### PR DESCRIPTION
exa is no longer maintained and seems to have been dropped from termux's repository. This causes the script to break

Updated exa -> eza and things seem to be working perfectly now :)

Reference: https://github.com/ogham/exa/issues/1243