### PR TITLE
Update README.md - install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository provides a script to set up an XFCE desktop environment and a De
 To install, execute the following command in Termux:
 
 ```bash
-curl -sL https://raw.githubusercontent.com/phoenixbyrd/Termux_XFCE/main/install_xfce_native.sh -o install.sh && bash install.sh
+curl -sLO https://raw.githubusercontent.com/phoenixbyrd/Termux_XFCE/main/install_xfce_native.sh && bash install_xfce_native.sh
 ```
 
 ## Support and Community


### PR DESCRIPTION
Updated install command to fix error on `rm install_xfce_native.sh` in script

What happens is, the current install command saves the files as `install.sh`, but the script itself expects it to be saved with original name, and tries to delete itself with `rm install_xfce_native.sh` once everything is done.
This results in a error upon the completion of script.

This PR updates the installation command, saving the file with original name and let the script delete itself after things are complete, as expected.